### PR TITLE
Added support for loadBalancerSourceRanges

### DIFF
--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -962,6 +962,12 @@ spec:
   selector:
     server: {{ .selector | quote }}
   type: {{ $lvars.type }}
+{{- if .service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .service.loadBalancerSourceRanges }}
+  - {{ $cidr }}
+  {{- end }}
+{{ end }}
 {{- if $lvars.ingress }} 
 ---
 apiVersion: networking.k8s.io/v1

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -826,6 +826,11 @@
         "labels": {
           "type": "object",
           "additionalProperties": { "type": "string" }
+        },
+        "loadBalancerSourceRanges": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "A list of CIDR ranges that you would like to allow for access to the Service"
         }
       }
     },

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -473,6 +473,8 @@ esp:
     #- name: linkname
     #  description: "some description"
     #  url: "http://abc.com/def?g=1"
+    ## CIDRS allowed to access this service.
+    #loadBalancerSourceRanges: [1.2.3.4/32, 5.6.7.8/32]
   #resources:
   #  cpu: "1"
   #  memory: "2G"


### PR DESCRIPTION
Service template updated to support the use of Ingress IP Filtering:
https://cloud.google.com/kubernetes-engine/docs/concepts/security-overview#filtering_load_balanced_traffic

> To configure this filtering, you can use the loadBalancerSourceRanges configuration of the Service object. With this configuration parameter, you can provide a list of CIDR ranges that you would like to allow for access to the Service. If you do not configure loadBalancerSourceRanges, all addresses are allowed to access the Service via its external IP.


Tested against ECLWatch. Example configuration:
`     loadBalancerSourceRanges:  [1.2.3.4/32, 5.6.7.8/32]`